### PR TITLE
Fix for 'assembled' data sets without coverage value.

### DIFF
--- a/stages/pipeline_qc
+++ b/stages/pipeline_qc
@@ -130,6 +130,9 @@ if($assembled eq '1') {
       my $seq = $1;
       my $abun = $2;
       print ABUN "$seq\t$abun\n";
+    } elsif($line =~ /^>(\S+).*$/) {
+      my $seq = $1;
+      print ABUN "$seq\t1\n";
     }
   }
   close SEQS;


### PR DESCRIPTION
Added code so that even if user submits data with 'assembled' option but doesn't format header to include coverage information, script will still output abundance information giving each sequence without a coverage value an abundance of 1.
