### PR TITLE
Fixed parallel clustering to provide unique cluster ID's

### DIFF
--- a/bin/parallel_cluster
+++ b/bin/parallel_cluster
@@ -17,7 +17,6 @@ Produces 3 output files based on inputed output_name and type:
 
 fasta_re = re.compile('^>')
 TMP_DIR  = None
-PROC_NUM = 0
 P_IDENT  = 0
 SEQ_TYPE = ''
 type_set = { 'aa': 'faa',
@@ -64,8 +63,9 @@ def split_fasta(infile, bytes):
     return files
 
 def run_cluster(fname):
-    global PROC_NUM
-    runtmp = os.path.join(TMP_DIR, 'tmp.%s.%d'%(os.path.basename(fname), PROC_NUM))
+    str_list = re.split( r'\.', fname)
+    file_count = int(str_list[len(str_list)-1])
+    runtmp = os.path.join(TMP_DIR, 'tmp.%s'%(os.path.basename(fname)))
     os.mkdir(runtmp)
     fExt  = type_set[SEQ_TYPE]
     outF  = fname + '.out'
@@ -81,8 +81,7 @@ def run_cluster(fname):
     write_file(so2+"\n"+se2, logO, 1)
     so3, se3 = run_cmd(['qiime-uclust', '--input', sortF, '--uc2fasta', ucF, '--types', 'SH', '--output', seqF, '--tmpdir', runtmp])
     write_file(so3+"\n"+se3, logO, 1)
-    PROC_NUM += 1
-    so4, se4 = run_cmd(['process_clusters', '-u', seqF, '-p', '%s%d_%d.'%(SEQ_TYPE, P_IDENT, PROC_NUM), '-m', mapO, '-f', seqO])
+    so4, se4 = run_cmd(['process_clusters', '-u', seqF, '-p', '%s%d_%d.'%(SEQ_TYPE, P_IDENT, file_count), '-m', mapO, '-f', seqO])
     write_file(so4+"\n"+se4, logO, 1)
     return outF
 
@@ -148,7 +147,7 @@ def main(args):
     if size_bytes > file_bytes:
         if opts.verbose: sys.stdout.write("File %s smaller than %d Mb, running with 1 processor\n"%(in_fasta, opts.size))
         shutil.copyfile(in_fasta, in_fasta+'.tmp')
-        sfiles   = [in_fasta+'.tmp']
+        sfiles   = [in_fasta+'.tmp.'+str(len(sfiles)+1)]
         min_proc = 1
     else:
         if opts.verbose: sys.stdout.write("Splitting file %s ... "%in_fasta)


### PR DESCRIPTION
Cluster ID's being generated were not always unique.  Verified new code on job 81348.

[mgrastprod@berlin:analysis] wc -l old/550.cluster.aa90.mapping
552704 old/550.cluster.aa90.mapping
[mgrastprod@berlin:analysis] cut -s -f1 old/550.cluster.aa90.mapping | sort | uniq | wc -l
491524

[mgrastprod@berlin:analysis] wc -l new/550.cluster.aa90.mapping
552704 new/550.cluster.aa90.mapping
[mgrastprod@berlin:analysis] cut -s -f1 new/550.cluster.aa90.mapping | sort | uniq | wc -l
552704
