### PR TITLE
Auto-detect file type in consensus.py

### DIFF
--- a/bin/consensus.py
+++ b/bin/consensus.py
@@ -10,6 +10,16 @@ g = array.array('L')
 t = array.array('L')
 n = array.array('L')
 
+def determinetype(infile):
+  cmd = ["head", "-n", "1", infile]
+  p1 = subprocess.check_output(cmd)
+  firstchar = p1[0]
+  if firstchar == "@":
+    return "fastq"
+  elif firstchar == ">":
+    return "fasta"
+  sys.stderr.write("Cannot determine file type of %s\n"%(infile))
+  exit(1)
 def countseqs(infile, type):
   if type == 'fasta':
     cmd = ['grep', '-c', '^>', infile]
@@ -77,7 +87,7 @@ if __name__ == '__main__':
   parser = OptionParser(usage)
   parser.add_option("-i", "--input", dest="input", default=None, help="Input sequence file.")
   parser.add_option("-o", "--output", dest="output", default=None, help="Output file.")
-  parser.add_option("-t", "--type", dest="type", default='fasta', help="file type: fasta, fastq [default 'fasta']")
+  parser.add_option("-t", "--type", dest="type", default='fasta', help="file type: fasta, fastq [ignored]")
   parser.add_option("-b", "--bp_max", dest="bp_max", default=100, type="int", help="max number of bps to process [default 100]")
   parser.add_option("-s", "--seq_max", dest="seq_max", default=100000, type="int", help="max number of seqs to process [default 100000]")
   parser.add_option("-v", "--verbose", dest="verbose", action="store_true", default=False, help="Wordy [default off]")
@@ -85,14 +95,14 @@ if __name__ == '__main__':
   (opts, args) = parser.parse_args()
   if not (opts.input and os.path.isfile(opts.input) and opts.output):
     parser.error("Missing input/output files")
-
+  detectedtype = determinetype(opts.input)
   if opts.verbose: sys.stdout.write("Counting sequences in %s ... "%opts.input)
-  seqnum = countseqs(opts.input, opts.type)
+  seqnum = countseqs(opts.input, detectedtype)
   seqper = (opts.seq_max * 1.0) / seqnum
   if opts.verbose: sys.stdout.write("Done: %d seqs found, %f %% of sequences will be processed\n"%(seqnum, (seqper*100)))
 
   if opts.verbose: sys.stdout.write("Populating bp matrixes ... ")
   initialize(opts.bp_max)
-  seqs = populate(opts.input, opts.type, opts.bp_max, seqper)
+  seqs = populate(opts.input, detectedtype, opts.bp_max, seqper)
   printtable(opts.output, opts.bp_max)
   if opts.verbose: sys.stdout.write("Done: %d of %d sequences processed\n"%(seqs, seqnum))


### PR DESCRIPTION
This code was failing in the wrong way--calculating corrupt data rather than throwing an error.  

This change should remove some instances of the bad behavior.  The `-t` option is retained for backwards compatibility, even though it is ignored.
