### PR TITLE
Fixed bug in AWE clustering stages.  Even when clustering was successful...

### DIFF
--- a/awecmd/awe_cluster_parallel.pl
+++ b/awecmd/awe_cluster_parallel.pl
@@ -77,7 +77,7 @@ if ((-s $fasta_file) > 1024) {
       system("cp $input_fasta $output_prefix.$fext");
       system("touch $output_prefix.mapping");
   } else {
-     if ((-s $output_prefix.$fext) == 0) {
+     if ((-s "$output_prefix.$fext") == 0) {
         system("cp $input_fasta $output_prefix.$fext");
         system("touch $output_prefix.mapping");
      }


### PR DESCRIPTION
... in reducing the size of the file, the input file was always being copied to the output file.
