### PR TITLE
Changed db path handling in awe_blat_rna.pl

### DIFF
--- a/awecmd/awe_blat_rna.pl
+++ b/awecmd/awe_blat_rna.pl
@@ -36,11 +36,19 @@ if ($help){
     exit 1;
 }
 
-my $refdb_dir = ".";
-if ($ENV{'REFDBPATH'}) {
-  $refdb_dir = $ENV{'REFDBPATH'};
+my $rna_nr_path = undef ;
+
+if (-s $rna_nr) {
+  $rna_nr_path = $rna_nr;
 }
-my $rna_nr_path = $refdb_dir."/".$rna_nr;
+else{
+  my $refdb_dir = ".";
+  if ($ENV{'REFDBPATH'}) {
+    $refdb_dir = $ENV{'REFDBPATH'};
+  }
+  $rna_nr_path = $refdb_dir."/".$rna_nr;
+}
+
 unless (-s $rna_nr_path) {
     PipelineAWE::logger('error', "rna_nr not exist: $rna_nr_path");
     exit 1;


### PR DESCRIPTION
Changed db path handling. Can be absolute and not only relative to current working dir or based on $REFDBPATH.

Did test with:

1. awe_blat_rna.pl input Data/Inputs/myCluster.rna97.fna -rna_nr Data/Inputs/md5rna.clust -rna_nr_version myVersion -output test1.sims => ok

2. awe_blat_rna.pl -input Data/Inputs/myCluster.rna97.fna -rna_nr /pipeline/CWL/Data/Inputs/md5rna.clust -rna_nr_version myVersion -output test2.sims => ok

3. awe_blat_rna.pl -input Data/Inputs/myCluster.rna97.fna -rna_nr md5rna.clust -rna_nr_version myVersion -output test3.sims => not ok
Unknown option: rna_nr_version
[2017/03/27 15:34:29] [ERROR] rna_nr not exist: ./md5rna.clust

4. export REFDBPATH=/pipeline/CWL/Data/Inputs/ ; awe_blat_rna.pl -input Data/Inputs/myCluster.rna97.fna -rna_nr md5rna.clust -rna_nr_version myVersion -output test4.sims => ok

which is expected behavior and backwards compatible  